### PR TITLE
fix: correct Blocksmith typo in JS comment

### DIFF
--- a/src/assets/js/blocksmith.js
+++ b/src/assets/js/blocksmith.js
@@ -152,7 +152,7 @@
             (matrixFieldSettings[matrixFieldHandle]?.enablePreview ?? true) ===
               false
           ) {
-            // Show Matrix Extended Context Menu if Blpocksmith preview disabled for this field
+            // Show Matrix Extended Context Menu if Blocksmith preview disabled for this field
             requestAnimationFrame(() => {
               const menuId = this.$trigger.attr("aria-controls");
               const menuEl = document.getElementById(menuId);


### PR DESCRIPTION
## Summary
- fix Blocksmith typo in JS comment

## Testing
- `npm run check-format` *(fails: Cannot find package '@prettier/plugin-php')*