### PR TITLE
Add button group settings

### DIFF
--- a/src/Blocksmith.php
+++ b/src/Blocksmith.php
@@ -400,6 +400,7 @@ class Blocksmith extends Plugin
         $config->remove("blocksmith.blocksmithMatrixFields");
         $config->remove("blocksmith.blocksmithBlocks");
         $config->remove("blocksmith.blocksmithCategories");
+        $config->remove("blocksmith.buttonGroups");
         $config->remove("blocksmith.__migrationCompleted");
 
         Craft::info("Blocksmith Project Config entries removed.", __METHOD__);

--- a/src/assets/css/blocksmith.css
+++ b/src/assets/css/blocksmith.css
@@ -644,3 +644,21 @@ ul.matrix-extended.blocksmith-preview-disabled
 .blocksmith-floating-btngroup.btns-removed::after {
   visibility: visible;
 }
+
+/* Dropdown styles for Button Groups */
+.blocksmith-dropdown {
+  position: relative;
+}
+.blocksmith-dropdown-menu {
+  display: none;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  background: #fff;
+  border: 1px solid rgba(96, 125, 159, 0.5);
+  padding: 4px;
+  z-index: 10;
+}
+.blocksmith-dropdown.open .blocksmith-dropdown-menu {
+  display: block;
+}

--- a/src/controllers/BlocksmithModalController.php
+++ b/src/controllers/BlocksmithModalController.php
@@ -61,6 +61,8 @@ class BlocksmithModalController extends Controller
                 "blocksmith.blocksmithCategories"
             ) ?? [];
 
+        $groupConfig = Craft::$app->projectConfig->get('blocksmith.buttonGroups') ?? [];
+
         $fields = array_filter(
             $fieldsService->getAllFields(),
             fn($field) => $field instanceof \craft\fields\Matrix
@@ -106,6 +108,12 @@ class BlocksmithModalController extends Controller
                     }
                 }
 
+                $buttonGroupUid = $block['buttonGroupUid'] ?? null;
+                $buttonGroupName = null;
+                if ($buttonGroupUid && isset($groupConfig[$buttonGroupUid])) {
+                    $buttonGroupName = $groupConfig[$buttonGroupUid]['name'];
+                }
+
                 $previewImage = Blocksmith::getInstance()->service->resolvePreviewImageUrl(
                     $entryTypeHandle,
                     $previewImagePath
@@ -130,6 +138,8 @@ class BlocksmithModalController extends Controller
                     "description" => $description,
                     "categories" => $categories,
                     "previewImage" => $previewImage,
+                    "buttonGroupUid" => $buttonGroupUid,
+                    "buttonGroupName" => $buttonGroupName,
                     "matrixFields" => $matrixFields,
                     "previewStorageMode" => $previewStorageMode,
                 ];

--- a/src/services/BlocksmithService.php
+++ b/src/services/BlocksmithService.php
@@ -123,6 +123,37 @@ class BlocksmithService
     }
 
     /**
+     * Retrieves all button groups from Project Config, sorted by sortOrder.
+     *
+     * @return array
+     */
+    public function getAllButtonGroups(): array
+    {
+        $groupsFromConfig = Craft::$app->projectConfig->get('blocksmith.buttonGroups') ?? [];
+
+        $groups = [];
+        foreach ($groupsFromConfig as $uid => $data) {
+            if (!isset($data['name'])) {
+                Craft::warning(
+                    "Blocksmith: Skipping invalid button group entry for UID {$uid}.",
+                    __METHOD__
+                );
+                continue;
+            }
+
+            $groups[] = [
+                'uid' => $uid,
+                'name' => $data['name'],
+                'sortOrder' => (int) ($data['sortOrder'] ?? 0),
+            ];
+        }
+
+        usort($groups, fn($a, $b) => $a['sortOrder'] <=> $b['sortOrder']);
+
+        return $groups;
+    }
+
+    /**
      * Resolves the preview image URL for a given block handle.
      *
      * This supports all previewStorageMode types:

--- a/src/templates/_settings/edit-block.twig
+++ b/src/templates/_settings/edit-block.twig
@@ -94,11 +94,32 @@
 						<p>{{ 'No categories available. Please add categories first in the categories settings page.'|t('blocksmith') }}</p>
 					</div>
 				</div>
-			{% endif %}
+{% endif %}
 
-			<div class="field">
-				<div class="heading">
-					<label for="previewImage">{{ "Preview Image"|t('blocksmith') }}</label>
+                        {% if block.buttonGroups is not empty %}
+                                <div class="field">
+                                        <div class="heading">
+                                                <label for="buttonGroupUid">{{ 'Group'|t('blocksmith') }}</label>
+                                        </div>
+                                        <div class="instructions">
+                                                {{ 'Assign this block to a group.'|t('blocksmith') }}
+                                        </div>
+                                        <div class="input">
+                                                {{ forms.selectField({
+                                                        name: 'buttonGroupUid',
+                                                        id: 'buttonGroupUid',
+                                                        options: block.buttonGroups|map(g => { label: g.name, value: g.uid }),
+                                                        value: block.selectedButtonGroup,
+                                                        includeEmptyOption: true,
+                                                        disabled: readOnly
+                                                }) }}
+                                        </div>
+                                </div>
+                        {% endif %}
+
+                        <div class="field">
+                                <div class="heading">
+                                        <label for="previewImage">{{ "Preview Image"|t('blocksmith') }}</label>
 				</div>
 				{% if block.useHandleBasedPreviews %}
 					{% if block.handleBasedImageExists %}

--- a/src/templates/_settings/edit-group.twig
+++ b/src/templates/_settings/edit-group.twig
@@ -1,0 +1,56 @@
+{# src/templates/_settings/edit-group.twig #}
+
+{% extends '_layouts/cp' %}
+{% import '_includes/forms' as forms %}
+{% import 'blocksmith/_includes/macros.twig' as macros %}
+
+{% set readOnly = not craft.app.config.general.allowAdminChanges %}
+{% set fullPageForm = not readOnly %}
+
+{% if readOnly %}
+	{% set contentNotice = readOnlyNotice() %}
+{% endif %}
+
+{% set crumbs = [
+    {
+        label: "Settings"|t('blocksmith'),
+        url: url('admin/settings')
+    },
+    {
+        label: "Plugins"|t('blocksmith'),
+        url: url('admin/settings/plugins')
+    },
+    {
+        label: "Groups"|t('blocksmith'),
+        url: url('blocksmith/settings/groups')
+    }
+] %}
+
+{% set title = group ? ("Edit Group" | t('blocksmith')) : ("New Group" | t('blocksmith')) %}
+
+{% block sidebar %}
+	{% include 'blocksmith/_settings/sidebar.twig' %}
+{% endblock %}
+
+{% block content %}
+        <input type="hidden" name="pluginHandle" value="blocksmith">
+        <input type="hidden" name="id" value="{{ group.uid ?? '' }}">
+        {{ actionInput('blocksmith/blocksmith/save-group') }}
+
+	<div class="blocksmith-settings-wrapper">
+		<div class="blocksmith-settings-content">
+			<h1>{{ title }}</h1>
+
+			{{ forms.textField({
+                label: 'Name'|t('blocksmith'),
+                name: 'name',
+                id: 'name',
+                value: group.name ?? '',
+                required: true,
+                instructions: 'Enter the name of the group.'|t('blocksmith'),
+                disabled: readOnly,
+            }) }}
+
+		</div>
+	</div>
+{% endblock %}

--- a/src/templates/_settings/groups.twig
+++ b/src/templates/_settings/groups.twig
@@ -1,0 +1,93 @@
+{# src/templates/_settings/groups.twig #}
+
+{% extends '_layouts/cp' %}
+
+{% set readOnly = not craft.app.config.general.allowAdminChanges %}
+
+{% if readOnly %}
+	{% set contentNotice = readOnlyNotice() %}
+{% endif %}
+
+{% set title = "Groups" | t('blocksmith') %}
+
+{% block sidebar %}
+	{% include 'blocksmith/_settings/sidebar.twig' %}
+{% endblock %}
+
+{% do view.registerAssetBundle('craft\\web\\assets\\admintable\\AdminTableAsset') %}
+
+{% do view.registerTranslations('blocksmith', [
+    "Groups",
+    "New Group",
+    "No groups exist yet.",
+]) %}
+
+{% block actionButton %}
+        {% if not readOnly %}
+                <a href="{{ url('blocksmith/settings/groups/new') }}" class="btn submit add icon">{{ "New Group"|t('blocksmith') }}</a>
+        {% endif %}
+{% endblock %}
+
+{% set crumbs = [
+    {
+        label: "Settings"|t('blocksmith'),
+        url: url('admin/settings')
+    },
+    {
+        label: "Plugins"|t('blocksmith'),
+        url: url('admin/settings/plugins')
+    }
+] %}
+
+{% block content %}
+	<div class="blocksmith-settings-wrapper">
+		<div class="blocksmith-settings-content">
+
+                        <h1 style="margin-bottom: 3rem;">{{ "Configure Groups"|t('blocksmith') }}</h1>
+                        <div id="blocksmith-groups-vue-admin-table"></div>
+			<div class="blocksmith-hint" style="margin-top: 2rem;">
+                                <strong>{{ "Note: "|t('blocksmith') }}</strong>{{ "Categories are only used in the preview modal and do not affect how Button Groups are displayed."|t('blocksmith') }}
+			</div>
+		</div>
+	</div>
+{% endblock %}
+
+
+{% set tableData = [] %}
+{% for group in groups %}
+        {% set tableData = tableData|merge([{
+        id: group.uid,
+        title: group.name,
+        url: url('blocksmith/settings/groups/edit/' ~ group.uid),
+    }]) %}
+{% endfor %}
+
+
+{% js %}
+new Craft.VueAdminTable({
+    columns: [
+        {
+            name: '__slot:title',
+            title: Craft.t('blocksmith', 'Name'),
+        },
+    ],
+    container: '#blocksmith-groups-vue-admin-table',
+    emptyMessage: Craft.t('blocksmith', 'No groups exist yet.'),
+    tableData:
+{{ tableData|json_encode|raw }},
+{% if not readOnly %}
+        deleteAction: 'blocksmith/blocksmith/delete-group',
+                                                    reorderAction: 'blocksmith/blocksmith/reorder-groups',
+                                                    onSortChange: (sortedIds) => {
+                                                        Craft.sendActionRequest('POST', 'blocksmith/reorder-groups', {
+                                                            data: { ids: sortedIds },
+                                                        });
+                                                    },
+{% endif %}
+slots: {
+        title: (row) => {
+            return `<a href="${row.url}">${row.title}</a>`;
+						        },
+						    },
+						});
+{% endjs %}

--- a/src/templates/_settings/sidebar.twig
+++ b/src/templates/_settings/sidebar.twig
@@ -11,12 +11,18 @@
 					{{ "General Settings"|t("blocksmith") }}
 				</a>
 			</li>
-			<li>
-				<a href="{{ url('blocksmith/settings/categories') }}" 
-				   {% if currentItem == "categories" %} class="sel"{% endif %}>
-					{{ "Categories"|t("blocksmith") }}
-				</a>
-			</li>
+                        <li>
+                                <a href="{{ url('blocksmith/settings/categories') }}"
+                                   {% if currentItem == "categories" %} class="sel"{% endif %}>
+                                        {{ "Categories"|t("blocksmith") }}
+                                </a>
+                        </li>
+                        <li>
+                                <a href="{{ url('blocksmith/settings/groups') }}"
+                                   {% if currentItem == 'groups' %} class="sel"{% endif %}>
+                                        {{ 'Groups'|t('blocksmith') }}
+                                </a>
+                        </li>
 			<li>
 				<a href="{{ url('blocksmith/settings/matrix-fields') }}"
 					{% if currentPath == "blocksmith/settings/matrix-fields" %} class="sel"{% endif %}>

--- a/src/translations/ar/blocksmith.php
+++ b/src/translations/ar/blocksmith.php
@@ -135,4 +135,9 @@ return [
     "UI Mode" => "وضع الواجهة",
     "Preview Modal" => "نافذة المعاينة",
     "Button Group" => "Button Group",
+    "Groups" => "Groups",
+    "Group" => "Group",
+    "New Group" => "New Group",
+    "No groups exist yet." => "No groups exist yet.",
+    "No group assigned" => "No group assigned",
 ];

--- a/src/translations/cs/blocksmith.php
+++ b/src/translations/cs/blocksmith.php
@@ -136,4 +136,9 @@ return [
     "UI Mode" => "Režim rozhraní",
     "Preview Modal" => "Náhledové okno",
     "Button Group" => "Button Group",
+    "Groups" => "Groups",
+    "Group" => "Group",
+    "New Group" => "New Group",
+    "No groups exist yet." => "No groups exist yet.",
+    "No group assigned" => "No group assigned",
 ];

--- a/src/translations/da/blocksmith.php
+++ b/src/translations/da/blocksmith.php
@@ -136,4 +136,9 @@ return [
     "UI Mode" => "UI-tilstand",
     "Preview Modal" => "Preview-modal",
     "Button Group" => "Button Group",
+    "Groups" => "Groups",
+    "Group" => "Group",
+    "New Group" => "New Group",
+    "No groups exist yet." => "No groups exist yet.",
+    "No group assigned" => "No group assigned",
 ];

--- a/src/translations/de/blocksmith.php
+++ b/src/translations/de/blocksmith.php
@@ -137,4 +137,9 @@ return [
     "UI Mode" => "UI-Modus",
     "Preview Modal" => "Vorschau-Modal",
     "Button Group" => "Button Group",
+    "Groups" => "Groups",
+    "Group" => "Group",
+    "New Group" => "New Group",
+    "No groups exist yet." => "No groups exist yet.",
+    "No group assigned" => "No group assigned",
 ];

--- a/src/translations/el/blocksmith.php
+++ b/src/translations/el/blocksmith.php
@@ -137,4 +137,9 @@ return [
     "UI Mode" => "Λειτουργία διεπαφής",
     "Preview Modal" => "Παράθυρο προεπισκόπησης",
     "Button Group" => "Button Group",
+    "Groups" => "Groups",
+    "Group" => "Group",
+    "New Group" => "New Group",
+    "No groups exist yet." => "No groups exist yet.",
+    "No group assigned" => "No group assigned",
 ];

--- a/src/translations/en/blocksmith.php
+++ b/src/translations/en/blocksmith.php
@@ -135,4 +135,9 @@ return [
     "UI Mode" => "UI Mode",
     "Preview Modal" => "Preview Modal",
     "Button Group" => "Button Group",
+    "Groups" => "Groups",
+    "Group" => "Group",
+    "New Group" => "New Group",
+    "No groups exist yet." => "No groups exist yet.",
+    "No group assigned" => "No group assigned",
 ];

--- a/src/translations/es/blocksmith.php
+++ b/src/translations/es/blocksmith.php
@@ -138,4 +138,9 @@ return [
     "UI Mode" => "Modo de interfaz",
     "Preview Modal" => "Ventana de vista previa",
     "Button Group" => "Button Group",
+    "Groups" => "Groups",
+    "Group" => "Group",
+    "New Group" => "New Group",
+    "No groups exist yet." => "No groups exist yet.",
+    "No group assigned" => "No group assigned",
 ];

--- a/src/translations/fr/blocksmith.php
+++ b/src/translations/fr/blocksmith.php
@@ -136,4 +136,9 @@ return [
     "UI Mode" => "Mode d’interface",
     "Preview Modal" => "Fenêtre de prévisualisation",
     "Button Group" => "Button Group",
+    "Groups" => "Groups",
+    "Group" => "Group",
+    "New Group" => "New Group",
+    "No groups exist yet." => "No groups exist yet.",
+    "No group assigned" => "No group assigned",
 ];

--- a/src/translations/he/blocksmith.php
+++ b/src/translations/he/blocksmith.php
@@ -135,4 +135,9 @@ return [
     "UI Mode" => "מצב ממשק משתמש",
     "Preview Modal" => "חלון תצוגה מקדימה",
     "Button Group" => "Button Group",
+    "Groups" => "Groups",
+    "Group" => "Group",
+    "New Group" => "New Group",
+    "No groups exist yet." => "No groups exist yet.",
+    "No group assigned" => "No group assigned",
 ];

--- a/src/translations/it/blocksmith.php
+++ b/src/translations/it/blocksmith.php
@@ -136,4 +136,9 @@ return [
     "UI Mode" => "Modalità interfaccia",
     "Preview Modal" => "Finestra di anteprima",
     "Button Group" => "Button Group",
+    "Groups" => "Groups",
+    "Group" => "Group",
+    "New Group" => "New Group",
+    "No groups exist yet." => "No groups exist yet.",
+    "No group assigned" => "No group assigned",
 ];

--- a/src/translations/ja/blocksmith.php
+++ b/src/translations/ja/blocksmith.php
@@ -136,4 +136,9 @@ return [
     "UI Mode" => "UIモード",
     "Preview Modal" => "プレビューモーダル",
     "Button Group" => "Button Group",
+    "Groups" => "Groups",
+    "Group" => "Group",
+    "New Group" => "New Group",
+    "No groups exist yet." => "No groups exist yet.",
+    "No group assigned" => "No group assigned",
 ];

--- a/src/translations/ko/blocksmith.php
+++ b/src/translations/ko/blocksmith.php
@@ -136,4 +136,9 @@ return [
     "UI Mode" => "UI 모드",
     "Preview Modal" => "미리보기 모달",
     "Button Group" => "Button Group",
+    "Groups" => "Groups",
+    "Group" => "Group",
+    "New Group" => "New Group",
+    "No groups exist yet." => "No groups exist yet.",
+    "No group assigned" => "No group assigned",
 ];

--- a/src/translations/nl/blocksmith.php
+++ b/src/translations/nl/blocksmith.php
@@ -136,4 +136,9 @@ return [
     "UI Mode" => "UI-modus",
     "Preview Modal" => "Previewvenster",
     "Button Group" => "Button Group",
+    "Groups" => "Groups",
+    "Group" => "Group",
+    "New Group" => "New Group",
+    "No groups exist yet." => "No groups exist yet.",
+    "No group assigned" => "No group assigned",
 ];

--- a/src/translations/pl/blocksmith.php
+++ b/src/translations/pl/blocksmith.php
@@ -136,4 +136,9 @@ return [
     "UI Mode" => "Tryb interfejsu",
     "Preview Modal" => "Okno podglądu",
     "Button Group" => "Button Group",
+    "Groups" => "Groups",
+    "Group" => "Group",
+    "New Group" => "New Group",
+    "No groups exist yet." => "No groups exist yet.",
+    "No group assigned" => "No group assigned",
 ];

--- a/src/translations/pt/blocksmith.php
+++ b/src/translations/pt/blocksmith.php
@@ -137,4 +137,9 @@ return [
     "UI Mode" => "Modo de interface",
     "Preview Modal" => "Janela de pré-visualização",
     "Button Group" => "Button Group",
+    "Groups" => "Groups",
+    "Group" => "Group",
+    "New Group" => "New Group",
+    "No groups exist yet." => "No groups exist yet.",
+    "No group assigned" => "No group assigned",
 ];

--- a/src/translations/ru/blocksmith.php
+++ b/src/translations/ru/blocksmith.php
@@ -136,4 +136,9 @@ return [
     "UI Mode" => "Режим интерфейса",
     "Preview Modal" => "Окно предварительного просмотра",
     "Button Group" => "Button Group",
+    "Groups" => "Groups",
+    "Group" => "Group",
+    "New Group" => "New Group",
+    "No groups exist yet." => "No groups exist yet.",
+    "No group assigned" => "No group assigned",
 ];

--- a/src/translations/sv/blocksmith.php
+++ b/src/translations/sv/blocksmith.php
@@ -137,4 +137,9 @@ return [
     "UI Mode" => "UI-läge",
     "Preview Modal" => "Förhandsgranskningsfönster",
     "Button Group" => "Button Group",
+    "Groups" => "Groups",
+    "Group" => "Group",
+    "New Group" => "New Group",
+    "No groups exist yet." => "No groups exist yet.",
+    "No group assigned" => "No group assigned",
 ];

--- a/src/translations/tr/blocksmith.php
+++ b/src/translations/tr/blocksmith.php
@@ -136,4 +136,9 @@ return [
     "UI Mode" => "Arayüz modu",
     "Preview Modal" => "Önizleme penceresi",
     "Button Group" => "Button Group",
+    "Groups" => "Groups",
+    "Group" => "Group",
+    "New Group" => "New Group",
+    "No groups exist yet." => "No groups exist yet.",
+    "No group assigned" => "No group assigned",
 ];

--- a/src/translations/uk/blocksmith.php
+++ b/src/translations/uk/blocksmith.php
@@ -138,4 +138,9 @@ return [
     "UI Mode" => "Режим інтерфейсу",
     "Preview Modal" => "Вікно попереднього перегляду",
     "Button Group" => "Button Group",
+    "Groups" => "Groups",
+    "Group" => "Group",
+    "New Group" => "New Group",
+    "No groups exist yet." => "No groups exist yet.",
+    "No group assigned" => "No group assigned",
 ];

--- a/src/translations/zh/blocksmith.php
+++ b/src/translations/zh/blocksmith.php
@@ -131,4 +131,9 @@ return [
     "UI Mode" => "界面模式",
     "Preview Modal" => "预览窗口",
     "Button Group" => "Button Group",
+    "Groups" => "Groups",
+    "Group" => "Group",
+    "New Group" => "New Group",
+    "No groups exist yet." => "No groups exist yet.",
+    "No group assigned" => "No group assigned",
 ];


### PR DESCRIPTION
## Summary
- support new `buttonGroups` project config
- CRUD actions and templates for button groups
- allow assigning blocks to a group
- expose group data via modal JSON API
- add dropdown-based grouping in JS button groups
- translate new strings

## Testing
- `npm run fix-format` *(fails: Cannot find package '@prettier/plugin-php')*